### PR TITLE
Monitor travel advice alerts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gem 'rake', '~> 10.5'
 
 gem 'rspec', '~> 3.4'
 gem 'webmock', '~> 1.22'
+gem 'timecop', '~> 0.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       multi_json (~> 1.10)
     thor (0.19.1)
     thread_safe (0.3.5)
+    timecop (0.8.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uber (0.0.15)
@@ -91,6 +92,7 @@ DEPENDENCIES
   google-api-client (~> 0.9.1)
   rake (~> 10.5)
   rspec (~> 3.4)
+  timecop (~> 0.8)
   webmock (~> 1.22)
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -2,26 +2,36 @@
 
 GOV.UK provides email alerts. This repo provides scripts that verify that emails have been sent for certain publications.
 
+Currently the script only looks at the [drug and medical advice
+alerts](https://www.gov.uk/drug-device-alerts) and [foreign travel advice
+alerts](https://www.gov.uk/foreign-travel-advice). Monitoring for other types of alerts may be added.
+
 ### Drug and medical advice alerts
 
-Currently the script only looks at the [drug and medical advice alerts](https://www.gov.uk/drug-device-alerts). Monitoring for other types of alerts may be added.
-
-To test that all of these alerts are sent to email subscribers, we've subscribed a number of email addresses to these publications (via [its email-signup page](https://www.gov.uk/drug-device-alerts/email-signup)).
+To test that all drug and device alerts are sent to email subscribers, we've subscribed a number of email addresses to these publications (via [its email-signup page](https://www.gov.uk/drug-device-alerts/email-signup)).
 
 Every hour we look at [the public RSS feed for alerts](https://www.gov.uk/drug-device-alerts.atom). We then check our email address has received an email for these publications via the [Google Gmail API](https://developers.google.com/gmail/api/).
 
 Note that drug alerts are so important that they have a special "urgent" flag in GovDelivery (this is set in the payload [specialist-publisher](https://github.com/alphagov/specialist-publisher) sends to
 [email-alert-api](https://github.com/alphagov/email-alert-api)). This means that even if somebody has requested a weekly or daily digested email for these alerts, they should receive the emails immediately. To tests this, we've subscribed three different email addresses to the alerts (for weekly digest, daily digest and immediately). In production `EMAILS_THAT_SHOULD_RECEIVE_DRUG_ALERTS` env var contains these three email addresses.
 
+### Travel advice alerts
+
+An email address has also been subscribed to the "Travel advice for all countries" [alerts](https://www.gov.uk/foreign-travel-advice/email-signup). Since there is no special casing for digests for these alerts, only a single email is used. The `EMAILS_THAT_SHOULD_RECEIVE_TRAVEL_ADVICE_ALERTS` env var is used to determine the addresses to query.
+
+The monitoring for these alerts looks at the [contentapi JSON feed](https://www.gov.uk/api/foreign-travel-advice.json) - the contentapi no longer powers the pages themselves but is a useful check separate from the publishing-api workflow.
+
 ## Technical documentation
 
 ### Running
 
-`bundle exec rake run`
+`bundle exec rake run` for the drug device alert checker
 
-This rake task will exit normally and not output anything if everything is okay.
+`bundle exec rake run` for the travel advice alert checker
 
-If it finds that some alerts have not been sent out, it will print the missing alerts and exit with a nonzero exit code. When run by Icinga, this will alert developers that something is wrong.
+Both rake tasks will exit normally and not output anything if everything is okay.
+
+If they find that some alerts have not been sent out, they will print the missing alerts and exit with a nonzero exit code. When run by Icinga, this will alert developers that something is wrong.
 
 ### Running the test suite
 

--- a/Rakefile
+++ b/Rakefile
@@ -13,3 +13,22 @@ task :run do
     exit(1)
   end
 end
+
+task :run_travel_alerts do
+  require_relative './lib/travel_advice_alert_email_verifier'
+
+  verifier = TravelAdviceAlertEmailVerifier.new
+
+  if verifier.have_all_alerts_been_emailed?
+    puts "All travel advice email alerts have been sent. Everything is okay!"
+  else
+    verifier.missing_alerts.each do |email, result|
+      /subject:(.*)/.match(result) do |country|
+        puts "#{email} has not received a travel advice email for #{country[1]}"
+      end
+    end
+
+    exit(1)
+  end
+end
+

--- a/lib/alert_email_verifier.rb
+++ b/lib/alert_email_verifier.rb
@@ -1,0 +1,41 @@
+require_relative './inbox'
+
+class AlertEmailVerifier
+  attr_reader :missing_alerts, :emailed_alerts
+
+  def initialize
+    @emailed_alerts = []
+    @missing_alerts = []
+    run_report
+  end
+
+  def have_all_alerts_been_emailed?
+    @missing_alerts.empty?
+  end
+
+private
+  def run_report
+    latest_alert_contents.all? do |contents|
+      emails_that_should_have_received_alert.all? do |email|
+        if has_email_address_received_email_with_contents?(email: email, contents: contents)
+          @emailed_alerts << [email, contents]
+        else
+          @missing_alerts << [email, contents]
+        end
+      end
+    end
+  end
+
+  def has_email_address_received_email_with_contents?(email:, contents:)
+    count = inbox.message_count_for_query("#{contents} to:#{email}")
+    count != 0
+  end
+
+  def inbox
+    @inbox ||= Inbox.new
+  end
+
+  def latest_alert_contents
+    []
+  end
+end

--- a/lib/drug_alert_email_verifier.rb
+++ b/lib/drug_alert_email_verifier.rb
@@ -1,46 +1,12 @@
-require_relative './inbox'
 require_relative './drug_alerts'
+require_relative './alert_email_verifier'
 
-class DrugAlertEmailVerifier
-  attr_reader :missing_alerts
-
-  def initialize
-    @emailed_alerts = []
-    @missing_alerts = []
-    run_report
-  end
-
-  def have_all_alerts_been_emailed?
-    @missing_alerts.empty?
-  end
-
-private
-  def run_report
-    latest_drug_alert_urls.all? do |url|
-      emails_that_should_have_received_alert.all? do |email|
-        if has_email_address_received_email_with_contents?(email: email, contents: url)
-          @emailed_alerts << [email, url]
-        else
-          @missing_alerts << [email, url]
-        end
-      end
-    end
+class DrugAlertEmailVerifier < AlertEmailVerifier
+  def latest_alert_contents
+    DrugAlerts.new.latest_drug_alert_urls
   end
 
   def emails_that_should_have_received_alert
     ENV.fetch('EMAILS_THAT_SHOULD_RECEIVE_DRUG_ALERTS').split(',')
-  end
-
-  def has_email_address_received_email_with_contents?(email:, contents:)
-    count = inbox.message_count_for_query("#{contents} to:#{email}")
-    count != 0
-  end
-
-  def inbox
-    @inbox ||= Inbox.new
-  end
-
-  def latest_drug_alert_urls
-    DrugAlerts.new.latest_drug_alert_urls
   end
 end

--- a/lib/travel_advice_alert_email_verifier.rb
+++ b/lib/travel_advice_alert_email_verifier.rb
@@ -1,0 +1,12 @@
+require_relative './travel_advice_alerts'
+require_relative './alert_email_verifier'
+
+class TravelAdviceAlertEmailVerifier < AlertEmailVerifier
+  def latest_alert_contents
+    TravelAdviceAlerts.new.latest_travel_advice_alerts
+  end
+
+  def emails_that_should_have_received_alert
+    ENV.fetch('EMAILS_THAT_SHOULD_RECEIVE_TRAVEL_ADVICE_ALERTS').split(',')
+  end
+end

--- a/lib/travel_advice_alerts.rb
+++ b/lib/travel_advice_alerts.rb
@@ -1,0 +1,47 @@
+require 'open-uri'
+require 'json'
+require 'time'
+
+class TravelAdviceAlerts
+  FEED_URL = "https://www.gov.uk/api/foreign-travel-advice.json"
+
+  def latest_travel_advice_alerts
+    # Extract the countries updated from two days to one hour ago.
+    # Unlike with drug alerts, we expect multiple updates from the same set of
+    # 225 countries, so search on update time + country rather than the linked url.
+    open(FEED_URL) do |raw_json|
+      JSON.load(raw_json)["details"]["countries"]
+        .map { |json_entry| TravelAdviceEntry.new(json_entry) }
+        .select(&:updated_recently?)
+        .map(&:search_value)
+    end
+  end
+
+  class TravelAdviceEntry
+    attr_reader :entry
+
+    def initialize(entry)
+      @entry = entry
+    end
+
+    def updated_at
+      @updated_at ||= Time.parse(entry["updated_at"])
+    end
+
+    def alert_time
+      updated_at.utc.strftime("%d-%m-%Y %H:%M %p GMT")
+    end
+
+    def updated_recently?
+      Time.now - 172800 <= updated_at && updated_at <= Time.now - 3600
+    end
+
+    def country
+      entry["name"]
+    end
+
+    def search_value
+      %Q("#{alert_time}" subject:#{country})
+    end
+  end
+end

--- a/spec/features/drug_alert_email_verification_spec.rb
+++ b/spec/features/drug_alert_email_verification_spec.rb
@@ -27,14 +27,7 @@ RSpec.describe "Drug email alert verifier" do
   end
 
   def given_credentials_for_the_google_api_have_been_set
-    ENV['GOOGLE_OAUTH_CREDENTIALS'] = '{"client_id":"my-google-client-id","access_token":"my-access-token","refresh_token":"my-refresh-token","scope":["https://www.googleapis.com/auth/gmail.readonly"],"expiration_time_millis":1454336608000}'
-    ENV['GOOGLE_CLIENT_ID'] = 'my-google-client-id'
-    ENV['GOOGLE_CLIENT_SECRET'] = 'my-google-client-secret'
-    ENV['EMAILS_THAT_SHOULD_RECEIVE_DRUG_ALERTS'] = 'a@example.org,b@example.org'
-
-    # the response there doesn't matter, as long as it's JSON.
-    stub_request(:post, "https://www.googleapis.com/oauth2/v3/token").
-      to_return(body: "{}", headers: { 'Content-Type' => 'application/json'})
+    set_credentials
   end
 
   def and_there_are_drug_advice_alerts

--- a/spec/features/example_travel_alert_feed.json
+++ b/spec/features/example_travel_alert_feed.json
@@ -1,0 +1,118 @@
+{
+    "_response_info": {
+        "status": "ok"
+    },
+    "content_id": "08d48cdd-6b50-43ff-a53b-beab47f4aab0",
+    "details": {
+        "countries": [
+            {
+                "change_description": "Latest update: Summary - there have been a significant number of attacks in Kabul in recent months, including on the Afghan news agency and military bases and convoys ",
+                "id": "https://www.gov.uk/api/foreign-travel-advice%2Fafghanistan.json",
+                "identifier": "afghanistan",
+                "name": "Afghanistan",
+                "synonyms": [],
+                "updated_at": "2016-03-31T12:33:15+00:00",
+                "web_url": "https://www.gov.uk/foreign-travel-advice/afghanistan"
+            },
+            {
+                "change_description": "Latest Update: Local laws and customs section - homosexuality is decriminalised and anti-discrimination legislation is in place; Health section \u2013 removal of advice about haemorrhagic fever",
+                "id": "https://www.gov.uk/api/foreign-travel-advice%2Falbania.json",
+                "identifier": "albania",
+                "name": "Albania",
+                "synonyms": [],
+                "updated_at": "2016-03-30T12:24:46+00:00",
+                "web_url": "https://www.gov.uk/foreign-travel-advice/albania"
+            },
+            {
+                "change_description": "Latest update: Summary and Terrorism section \u2013 reports of an attempted suicide bomber being shot and killed in Tizi Ouzou on 23 March 2016",
+                "id": "https://www.gov.uk/api/foreign-travel-advice%2Falgeria.json",
+                "identifier": "algeria",
+                "name": "Algeria",
+                "synonyms": [
+                    "Sahel"
+                ],
+                "updated_at": "2016-03-30T17:39:29+00:00",
+                "web_url": "https://www.gov.uk/foreign-travel-advice/algeria"
+            },
+            {
+                "change_description": "Latest update: Summary \u2013 cases of locally transmitted Zika virus have been confirmed in the last 2 months; you should follow the advice of the National Travel Health Network and Centre and discuss your travel plans with your healthcare provider, particularly if you\u2019re pregnant or planning to become pregnant",
+                "id": "https://www.gov.uk/api/foreign-travel-advice%2Famerican-samoa.json",
+                "identifier": "american-samoa",
+                "name": "American Samoa",
+                "synonyms": [],
+                "updated_at": "2016-03-31T12:30:40+00:00",
+                "web_url": "https://www.gov.uk/foreign-travel-advice/american-samoa"
+            },
+            {
+                "change_description": "Latest update: this advice has been reviewed and re-issued without amendment",
+                "id": "https://www.gov.uk/api/foreign-travel-advice%2Fandorra.json",
+                "identifier": "andorra",
+                "name": "Andorra",
+                "synonyms": [],
+                "updated_at": "2016-03-29T17:20:20+00:00",
+                "web_url": "https://www.gov.uk/foreign-travel-advice/andorra"
+            },
+            {
+                "change_description": "Latest update: Summary \u2013 removal of precautionary security notice for US citizens advising them to avoid locations in Luanda; Entry requirements section \u2013 there is currently an outbreak of yellow fever in Luanda and other parts of Angola;  a vaccination is required for travellers arriving from all countries",
+                "id": "https://www.gov.uk/api/foreign-travel-advice%2Fangola.json",
+                "identifier": "angola",
+                "name": "Angola",
+                "synonyms": [],
+                "updated_at": "2016-03-30T15:42:44+00:00",
+                "web_url": "https://www.gov.uk/foreign-travel-advice/angola"
+            },
+            {
+                "change_description": "\r\nLatest update: this advice has been reviewed and re-issued without amendment\r\n\r\n",
+                "id": "https://www.gov.uk/api/foreign-travel-advice%2Fanguilla.json",
+                "identifier": "anguilla",
+                "name": "Anguilla",
+                "synonyms": [],
+                "updated_at": "2016-03-28T12:13:26+00:00",
+                "web_url": "https://www.gov.uk/foreign-travel-advice/anguilla"
+            },
+            {
+                "change_description": "Latest update: this advice has been reviewed and re-issued without amendment\r\n",
+                "id": "https://www.gov.uk/api/foreign-travel-advice%2Fantigua-and-barbuda.json",
+                "identifier": "antigua-and-barbuda",
+                "name": "Antigua and Barbuda",
+                "synonyms": [],
+                "updated_at": "2016-03-21T14:47:52+00:00",
+                "web_url": "https://www.gov.uk/foreign-travel-advice/antigua-and-barbuda"
+            },
+            {
+                "change_description": "Latest update - summary section - Reports of Dengue Fever outbreak in northern provinces",
+                "id": "https://www.gov.uk/api/foreign-travel-advice%2Fargentina.json",
+                "identifier": "argentina",
+                "name": "Argentina",
+                "synonyms": [],
+                "updated_at": "2016-03-31T14:57:20+00:00",
+                "web_url": "https://www.gov.uk/foreign-travel-advice/argentina"
+            },
+            {
+                "change_description": "Latest update: this advice has been reviewed and re-issued without amendment",
+                "id": "https://www.gov.uk/api/foreign-travel-advice%2Farmenia.json",
+                "identifier": "armenia",
+                "name": "Armenia",
+                "synonyms": [],
+                "updated_at": "2016-03-09T12:59:30+00:00",
+                "web_url": "https://www.gov.uk/foreign-travel-advice/armenia"
+            }
+        ],
+        "description": "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
+        "language": "en",
+        "need_extended_font": false,
+        "need_ids": [
+            "101191"
+        ]
+    },
+    "format": "custom-application",
+    "id": "https://www.gov.uk/api/foreign-travel-advice.json",
+    "in_beta": false,
+    "owning_app": "travel-advice-publisher",
+    "related": [],
+    "related_external_links": [],
+    "tags": [],
+    "title": "Foreign travel advice",
+    "updated_at": "2016-03-31T17:23:41+01:00",
+    "web_url": "https://www.gov.uk/foreign-travel-advice"
+}

--- a/spec/features/travel_advice_alert_email_verification_spec.rb
+++ b/spec/features/travel_advice_alert_email_verification_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+require 'timecop'
+require_relative './../../lib/travel_advice_alert_email_verifier'
+
+RSpec.describe TravelAdviceAlertEmailVerifier do
+  let(:verifier) { described_class.new }
+
+  before do
+    set_credentials
+    Timecop.freeze(Time.local(2016, 03, 31, 17, 30))
+  end
+
+  after do
+    Timecop.return
+  end
+
+  context "when there are travel advice alerts updated between two days and one hour ago" do
+    before do
+      stub_request(:get, TravelAdviceAlerts::FEED_URL).
+        to_return(body: File.read(File.dirname(__FILE__) + "/example_travel_alert_feed.json"))
+    end
+
+    context "when all emails are sent" do
+      before do
+        stub_request(
+          :get, "https://www.googleapis.com/gmail/v1/users/me/messages").
+          with(query: hash_including(:q)).
+          to_return(body: { resultSizeEstimate: 1 }.to_json, headers: { 'Content-Type' => 'application/json'})
+      end
+
+      it "reports that all items have been sent via email" do
+        expect(verifier.have_all_alerts_been_emailed?).to be true
+        expect(verifier.emailed_alerts.length).to eql(6)
+      end
+
+      it "does not query for items that are more than two days old" do
+        expect(verifier.missing_alerts.size).to eql(0)
+        expect(a_request(
+          :get, "https://www.googleapis.com/gmail/v1/users/me/messages").
+          with(query: { q: "\"09-03-2016 12:59 PM GMT\" subject:Armenia to:c@example.org" })).not_to have_been_made
+
+      end
+
+      context "when a travel advice item is updated but email has not been sent" do
+        before do
+          json = File.read(File.dirname(__FILE__) + "/example_travel_alert_feed.json")
+          json = json.gsub('2016-03-30T12:24:46+00:00', '2016-03-31T15:24:46+00:00')
+          stub_request(:get, TravelAdviceAlerts::FEED_URL).to_return(body: json)
+
+          stub_request(
+            :get, "https://www.googleapis.com/gmail/v1/users/me/messages").
+            with(query: { q: "\"31-03-2016 15:24 PM GMT\" subject:Albania to:c@example.org" }).
+            to_return(body: { resultSizeEstimate: 0 }.to_json, headers: { 'Content-Type' => 'application/json'})
+        end
+
+        it 'reports that there is an alert that has not been sent' do
+          expect(verifier.have_all_alerts_been_emailed?).to eql(false)
+          expect(verifier.missing_alerts.size).to eql(1)
+        end
+      end
+    end
+
+    context "when no emails are sent" do
+      before do
+        stub_request(
+          :get, "https://www.googleapis.com/gmail/v1/users/me/messages").
+          with(query: hash_including(:q)).
+          to_return(body: { resultSizeEstimate: 0 }.to_json, headers: { 'Content-Type' => 'application/json'})
+      end
+
+      it "reports that no alerts have been sent" do
+        expect(verifier.have_all_alerts_been_emailed?).to eql(false)
+        expect(verifier.missing_alerts.size).to eql(6)
+      end
+    end
+  end
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,3 +21,15 @@ RSpec.configure do |config|
   config.order = :random
   Kernel.srand config.seed
 end
+
+def set_credentials
+  ENV['GOOGLE_OAUTH_CREDENTIALS'] = '{"client_id":"my-google-client-id","access_token":"my-access-token","refresh_token":"my-refresh-token","scope":["https://www.googleapis.com/auth/gmail.readonly"],"expiration_time_millis":1454336608000}'
+  ENV['GOOGLE_CLIENT_ID'] = 'my-google-client-id'
+  ENV['GOOGLE_CLIENT_SECRET'] = 'my-google-client-secret'
+  ENV['EMAILS_THAT_SHOULD_RECEIVE_DRUG_ALERTS'] = 'a@example.org,b@example.org'
+  ENV['EMAILS_THAT_SHOULD_RECEIVE_TRAVEL_ADVICE_ALERTS'] = 'c@example.org'
+
+  # the response there doesn't matter, as long as it's JSON.
+  stub_request(:post, "https://www.googleapis.com/oauth2/v3/token").
+    to_return(body: "{}", headers: { 'Content-Type' => 'application/json'})
+end


### PR DESCRIPTION
Verify that all travel advice items that have been updated in the last two days have sent an alert to the Gmail account.

Travel advice works slightly differently from drug alerts, in that there is an existing list of countries and alerts are sent out when any of them are updated. So instead of checking for the existence of a link in the received emails, we query on the update time in the body of the email and the country name in the
subject.