### PR TITLE
Increase reliability

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ task :run do
       puts "#{email} has not received an email with #{url}"
     end
 
-    exit(1)
+    exit(2)
   end
 end
 
@@ -28,7 +28,7 @@ task :run_travel_alerts do
       end
     end
 
-    exit(1)
+    exit(2)
   end
 end
 

--- a/lib/google_auth.rb
+++ b/lib/google_auth.rb
@@ -5,6 +5,7 @@ class GoogleAuth
   def self.service
     service = Google::Apis::GmailV1::GmailService.new
     service.client_options.application_name = "GOV.UK Email monitoring service"
+    service.request_options.retries = 3
     service.authorization = get_credentials
     service
   end


### PR DESCRIPTION
Now that the travel-advice job is alerting out of hours, we should ensure that it only does so for the right reasons. This PR adds retries in the Google API client, and also switches the exit code when missing emails are found to 2 so that we can distinguish this state from the case when the script terminated for an abnormal reason.