### PR TITLE
Reduce threshold for recent travel advice

### DIFF
--- a/lib/travel_advice_alerts.rb
+++ b/lib/travel_advice_alerts.rb
@@ -33,7 +33,7 @@ class TravelAdviceAlerts
     end
 
     def updated_recently?
-      Time.now - 172800 <= updated_at && updated_at <= Time.now - 3600
+      Time.now - 172800 <= updated_at && updated_at <= Time.now - 900
     end
 
     def country


### PR DESCRIPTION
The current behaviour is that the travel advice must be at least an hour old before we start alerting on it.

15 minutes is probably a more reasonable threshold. Users should have received emails within 15 minutes of the advice being published.