### PR TITLE
Allow basic acknowledging of specific missing emails.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -52,4 +52,3 @@ task :run_travel_alerts do
     end
   end
 end
-

--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,10 @@ task :run do
   TaskRunner.new.verify_with_retries(verifier: verifier) do
     if verifier.have_all_alerts_been_emailed?
       puts "All email alerts have been sent. Everything is okay!"
+
+      verifier.acknowledged_alerts.each do |email, url|
+        puts "#{email} has not received an email with #{url} but has been acknowledged"
+      end
     else
       verifier.missing_alerts.each do |email, url|
         puts "#{email} has not received an email with #{url}"

--- a/lib/alert_email_verifier.rb
+++ b/lib/alert_email_verifier.rb
@@ -1,10 +1,15 @@
 require_relative './inbox'
 
 class AlertEmailVerifier
-  attr_reader :missing_alerts, :emailed_alerts
+  attr_reader :missing_alerts, :emailed_alerts, :acknowledged_alerts
+
+  ACKNOWLEDGED_EMAIL_CONTENTS = [
+    "https://www.gov.uk/drug-device-alerts/field-safety-notices-22-26-august-2016",
+  ].freeze
 
   def initialize
     @emailed_alerts = []
+    @acknowledged_alerts = []
     @missing_alerts = []
   end
 
@@ -17,6 +22,8 @@ class AlertEmailVerifier
       emails_that_should_have_received_alert.all? do |email|
         if has_email_address_received_email_with_contents?(email: email, contents: contents)
           @emailed_alerts << [email, contents]
+        elsif acknowledged_as_missing?(contents: contents)
+          @acknowledged_alerts << [email, contents]
         else
           @missing_alerts << [email, contents]
         end
@@ -29,6 +36,10 @@ private
   def has_email_address_received_email_with_contents?(email:, contents:)
     count = inbox.message_count_for_query("#{contents} to:#{email}")
     count != 0
+  end
+
+  def acknowledged_as_missing?(contents:)
+    ACKNOWLEDGED_EMAIL_CONTENTS.include?(contents)
   end
 
   def inbox


### PR DESCRIPTION
We need a mechanism to prevent 2nd line from being
alerted about missing emails which have been
investigated and triaged.  If we don't, 2nd
line support may miss other undelivered emails
unless they manually check the job every hour to
make sure a new email is not on this list.

This is a basic manual process for adding exclusions.