### PR TITLE
Add another drug alert to whitelist

### DIFF
--- a/lib/alert_email_verifier.rb
+++ b/lib/alert_email_verifier.rb
@@ -5,6 +5,7 @@ class AlertEmailVerifier
 
   ACKNOWLEDGED_EMAIL_CONTENTS = [
     "https://www.gov.uk/drug-device-alerts/field-safety-notices-22-26-august-2016",
+    "https://www.gov.uk/drug-device-alerts/accu-chek-insight-insulin-pump-system-risk-of-over-or-under-infusion-of-insulin",
   ].freeze
 
   def initialize


### PR DESCRIPTION
The fix for the publishing application is coming, but in the meantime another document has been published that we have acknowledged and want to clear the icinga alert.