### PR TITLE
Add another whitelisted doc for drug safety alerts

### DIFF
--- a/lib/alert_email_verifier.rb
+++ b/lib/alert_email_verifier.rb
@@ -6,6 +6,7 @@ class AlertEmailVerifier
   ACKNOWLEDGED_EMAIL_CONTENTS = [
     "https://www.gov.uk/drug-device-alerts/field-safety-notices-22-26-august-2016",
     "https://www.gov.uk/drug-device-alerts/accu-chek-insight-insulin-pump-system-risk-of-over-or-under-infusion-of-insulin",
+    "https://www.gov.uk/drug-device-alerts/airvo-2-and-myairvo-2-humidifier-risk-of-undetected-auditory-alarm",
   ].freeze
 
   def initialize


### PR DESCRIPTION
This document was published just before the fix was deployed for the publishing application.