### PR TITLE
Use the Content Store to fetch travel advice

### DIFF
--- a/lib/travel_advice_alerts.rb
+++ b/lib/travel_advice_alerts.rb
@@ -3,14 +3,14 @@ require 'json'
 require 'time'
 
 class TravelAdviceAlerts
-  FEED_URL = "https://www.gov.uk/api/foreign-travel-advice.json"
+  FEED_URL = "https://www.gov.uk/api/content/foreign-travel-advice"
 
   def latest_travel_advice_alerts
     # Extract the countries updated from two days to one hour ago.
     # Unlike with drug alerts, we expect multiple updates from the same set of
     # 225 countries, so search on update time + country rather than the linked url.
     open(FEED_URL) do |raw_json|
-      JSON.load(raw_json)["details"]["countries"]
+      JSON.load(raw_json)["links"]["children"]
         .map { |json_entry| TravelAdviceEntry.new(json_entry) }
         .select(&:updated_recently?)
         .map(&:search_value)
@@ -25,7 +25,7 @@ class TravelAdviceAlerts
     end
 
     def updated_at
-      @updated_at ||= Time.parse(entry["updated_at"])
+      @updated_at ||= Time.parse(entry["public_updated_at"])
     end
 
     def alert_time
@@ -37,7 +37,7 @@ class TravelAdviceAlerts
     end
 
     def country
-      entry["name"]
+      entry['country']['name']
     end
 
     def search_value

--- a/spec/features/example_travel_alert_feed.json
+++ b/spec/features/example_travel_alert_feed.json
@@ -1,117 +1,485 @@
 {
-    "_response_info": {
-        "status": "ok"
-    },
-    "content_id": "08d48cdd-6b50-43ff-a53b-beab47f4aab0",
-    "details": {
-        "countries": [
+  "analytics_identifier": null,
+  "base_path": "\/foreign-travel-advice",
+  "content_id": "08d48cdd-6b50-43ff-a53b-beab47f4aab0",
+  "document_type": "travel_advice_index",
+  "email_document_supertype": "other",
+  "first_published_at": "2016-02-29T09:24:10.000+00:00",
+  "format": null,
+  "government_document_supertype": "other",
+  "locale": "en",
+  "navigation_document_supertype": "other",
+  "need_ids": [
+
+  ],
+  "phase": "live",
+  "public_updated_at": "2016-03-31T17:23:41+01:00",
+  "publishing_app": "travel-advice-publisher",
+  "rendering_app": "frontend",
+  "schema_name": "travel_advice_index",
+  "title": "Foreign travel advice",
+  "updated_at": "2017-05-22T10:31:24.781Z",
+  "user_journey_document_supertype": "thing",
+  "withdrawn_notice": {
+
+  },
+  "links": {
+    "children": [
+      {
+        "analytics_identifier": null,
+        "api_path": "\/api\/content\/foreign-travel-advice\/dominica",
+        "base_path": "\/foreign-travel-advice\/dominica",
+        "content_id": "f0615634-9fbf-46f5-8435-5ae2d23698b6",
+        "description": "Latest travel advice for Dominica including safety and security, entry requirements, travel warnings and health",
+        "document_type": "travel_advice",
+        "locale": "en",
+        "public_updated_at": "2016-03-31T12:33:15+00:00",
+        "schema_name": "travel_advice",
+        "title": "Dominica travel advice",
+        "withdrawn": false,
+        "country": {
+          "slug": "dominica",
+          "name": "Dominica",
+          "synonyms": [
+
+          ]
+        },
+        "change_description": "Latest update: Summary and Terrorism section: updated information and advice about the threat from terrorism following a review of the way in which the UK government describes the threat from terrorism in travel advice for all countries and territories; there's no change in the UK government\u2019s assessment of the level of threat from terrorism in Dominica \r\n",
+        "links": {
+          "parent": [
             {
-                "change_description": "Latest update: Summary - there have been a significant number of attacks in Kabul in recent months, including on the Afghan news agency and military bases and convoys ",
-                "id": "https://www.gov.uk/api/foreign-travel-advice%2Fafghanistan.json",
-                "identifier": "afghanistan",
-                "name": "Afghanistan",
-                "synonyms": [],
-                "updated_at": "2016-03-31T12:33:15+00:00",
-                "web_url": "https://www.gov.uk/foreign-travel-advice/afghanistan"
-            },
-            {
-                "change_description": "Latest Update: Local laws and customs section - homosexuality is decriminalised and anti-discrimination legislation is in place; Health section \u2013 removal of advice about haemorrhagic fever",
-                "id": "https://www.gov.uk/api/foreign-travel-advice%2Falbania.json",
-                "identifier": "albania",
-                "name": "Albania",
-                "synonyms": [],
-                "updated_at": "2016-03-30T12:24:46+00:00",
-                "web_url": "https://www.gov.uk/foreign-travel-advice/albania"
-            },
-            {
-                "change_description": "Latest update: Summary and Terrorism section \u2013 reports of an attempted suicide bomber being shot and killed in Tizi Ouzou on 23 March 2016",
-                "id": "https://www.gov.uk/api/foreign-travel-advice%2Falgeria.json",
-                "identifier": "algeria",
-                "name": "Algeria",
-                "synonyms": [
-                    "Sahel"
-                ],
-                "updated_at": "2016-03-30T17:39:29+00:00",
-                "web_url": "https://www.gov.uk/foreign-travel-advice/algeria"
-            },
-            {
-                "change_description": "Latest update: Summary \u2013 cases of locally transmitted Zika virus have been confirmed in the last 2 months; you should follow the advice of the National Travel Health Network and Centre and discuss your travel plans with your healthcare provider, particularly if you\u2019re pregnant or planning to become pregnant",
-                "id": "https://www.gov.uk/api/foreign-travel-advice%2Famerican-samoa.json",
-                "identifier": "american-samoa",
-                "name": "American Samoa",
-                "synonyms": [],
-                "updated_at": "2016-03-31T12:30:40+00:00",
-                "web_url": "https://www.gov.uk/foreign-travel-advice/american-samoa"
-            },
-            {
-                "change_description": "Latest update: this advice has been reviewed and re-issued without amendment",
-                "id": "https://www.gov.uk/api/foreign-travel-advice%2Fandorra.json",
-                "identifier": "andorra",
-                "name": "Andorra",
-                "synonyms": [],
-                "updated_at": "2016-03-29T17:20:20+00:00",
-                "web_url": "https://www.gov.uk/foreign-travel-advice/andorra"
-            },
-            {
-                "change_description": "Latest update: Summary \u2013 removal of precautionary security notice for US citizens advising them to avoid locations in Luanda; Entry requirements section \u2013 there is currently an outbreak of yellow fever in Luanda and other parts of Angola;  a vaccination is required for travellers arriving from all countries",
-                "id": "https://www.gov.uk/api/foreign-travel-advice%2Fangola.json",
-                "identifier": "angola",
-                "name": "Angola",
-                "synonyms": [],
-                "updated_at": "2016-03-30T15:42:44+00:00",
-                "web_url": "https://www.gov.uk/foreign-travel-advice/angola"
-            },
-            {
-                "change_description": "\r\nLatest update: this advice has been reviewed and re-issued without amendment\r\n\r\n",
-                "id": "https://www.gov.uk/api/foreign-travel-advice%2Fanguilla.json",
-                "identifier": "anguilla",
-                "name": "Anguilla",
-                "synonyms": [],
-                "updated_at": "2016-03-28T12:13:26+00:00",
-                "web_url": "https://www.gov.uk/foreign-travel-advice/anguilla"
-            },
-            {
-                "change_description": "Latest update: this advice has been reviewed and re-issued without amendment\r\n",
-                "id": "https://www.gov.uk/api/foreign-travel-advice%2Fantigua-and-barbuda.json",
-                "identifier": "antigua-and-barbuda",
-                "name": "Antigua and Barbuda",
-                "synonyms": [],
-                "updated_at": "2016-03-21T14:47:52+00:00",
-                "web_url": "https://www.gov.uk/foreign-travel-advice/antigua-and-barbuda"
-            },
-            {
-                "change_description": "Latest update - summary section - Reports of Dengue Fever outbreak in northern provinces",
-                "id": "https://www.gov.uk/api/foreign-travel-advice%2Fargentina.json",
-                "identifier": "argentina",
-                "name": "Argentina",
-                "synonyms": [],
-                "updated_at": "2016-03-31T14:57:20+00:00",
-                "web_url": "https://www.gov.uk/foreign-travel-advice/argentina"
-            },
-            {
-                "change_description": "Latest update: this advice has been reviewed and re-issued without amendment",
-                "id": "https://www.gov.uk/api/foreign-travel-advice%2Farmenia.json",
-                "identifier": "armenia",
-                "name": "Armenia",
-                "synonyms": [],
-                "updated_at": "2016-03-09T12:59:30+00:00",
-                "web_url": "https://www.gov.uk/foreign-travel-advice/armenia"
+              "analytics_identifier": null,
+              "api_path": "\/api\/content\/foreign-travel-advice",
+              "base_path": "\/foreign-travel-advice",
+              "content_id": "08d48cdd-6b50-43ff-a53b-beab47f4aab0",
+              "description": "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
+              "document_type": "travel_advice_index",
+              "locale": "en",
+              "public_updated_at": "2017-05-18T13:28:24Z",
+              "schema_name": "travel_advice_index",
+              "title": "Foreign travel advice",
+              "withdrawn": false,
+              "links": {
+
+              },
+              "api_url": "https:\/\/www.gov.uk\/api\/content\/foreign-travel-advice",
+              "web_url": "https:\/\/www.gov.uk\/foreign-travel-advice"
             }
-        ],
-        "description": "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
-        "language": "en",
-        "need_ids": [
-            "101191"
-        ]
-    },
-    "format": "custom-application",
-    "id": "https://www.gov.uk/api/foreign-travel-advice.json",
-    "in_beta": false,
-    "owning_app": "travel-advice-publisher",
-    "related": [],
-    "related_external_links": [],
-    "tags": [],
-    "title": "Foreign travel advice",
-    "updated_at": "2016-03-31T17:23:41+01:00",
-    "web_url": "https://www.gov.uk/foreign-travel-advice"
+          ]
+        },
+        "api_url": "https:\/\/www.gov.uk\/api\/content\/foreign-travel-advice\/dominica",
+        "web_url": "https:\/\/www.gov.uk\/foreign-travel-advice\/dominica"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "\/api\/content\/foreign-travel-advice\/albania",
+        "base_path": "\/foreign-travel-advice\/albania",
+        "content_id": "2a3938e1-d588-45fc-8c8f-0f51814d5409",
+        "description": "Latest travel advice for Albania including safety and security, entry requirements, travel warnings and health",
+        "document_type": "travel_advice",
+        "locale": "en",
+        "public_updated_at": "2016-03-30T12:24:46+00:00",
+        "schema_name": "travel_advice",
+        "title": "Albania travel advice",
+        "withdrawn": false,
+        "country": {
+          "slug": "albania",
+          "name": "Albania",
+          "synonyms": [
+
+          ]
+        },
+        "change_description": "Latest update: Summary \u2013 the main opposition party has called for mass protests against the government in central Tirana on 13 May; monitor local and international media, take extra care and avoid all political rallies and demonstrations; gay pride events are also due to take place in central Tirana on 13 May; UK government staff in Albania have been advised to avoid these events because of the opposition protests taking place in central Tirana on that date",
+        "links": {
+          "parent": [
+            {
+              "analytics_identifier": null,
+              "api_path": "\/api\/content\/foreign-travel-advice",
+              "base_path": "\/foreign-travel-advice",
+              "content_id": "08d48cdd-6b50-43ff-a53b-beab47f4aab0",
+              "description": "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
+              "document_type": "travel_advice_index",
+              "locale": "en",
+              "public_updated_at": "2017-05-18T13:28:24Z",
+              "schema_name": "travel_advice_index",
+              "title": "Foreign travel advice",
+              "withdrawn": false,
+              "links": {
+
+              },
+              "api_url": "https:\/\/www.gov.uk\/api\/content\/foreign-travel-advice",
+              "web_url": "https:\/\/www.gov.uk\/foreign-travel-advice"
+            }
+          ]
+        },
+        "api_url": "https:\/\/www.gov.uk\/api\/content\/foreign-travel-advice\/albania",
+        "web_url": "https:\/\/www.gov.uk\/foreign-travel-advice\/albania"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "\/api\/content\/foreign-travel-advice\/st-maarten",
+        "base_path": "\/foreign-travel-advice\/st-maarten",
+        "content_id": "f752255c-de89-4b61-af7a-6233dd44a58a",
+        "description": "Latest travel advice for St Maarten including safety and security, entry requirements, travel warnings and health",
+        "document_type": "travel_advice",
+        "locale": "en",
+        "public_updated_at": "2016-03-30T17:39:29+00:00",
+        "schema_name": "travel_advice",
+        "title": "St Maarten travel advice",
+        "withdrawn": false,
+        "country": {
+          "slug": "st-maarten",
+          "name": "St Maarten",
+          "synonyms": [
+
+          ]
+        },
+        "change_description": "Latest update: Summary and Terrorism section - updated information and advice about the threat from terrorism following a review of the way in which the UK government describes the threat from terrorism in travel advice for all countries and territories; there\u2019s no change in the UK government\u2019s assessment of the level of threat from terrorism in St Maarten  ",
+        "links": {
+          "parent": [
+            {
+              "analytics_identifier": null,
+              "api_path": "\/api\/content\/foreign-travel-advice",
+              "base_path": "\/foreign-travel-advice",
+              "content_id": "08d48cdd-6b50-43ff-a53b-beab47f4aab0",
+              "description": "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
+              "document_type": "travel_advice_index",
+              "locale": "en",
+              "public_updated_at": "2017-05-18T13:28:24Z",
+              "schema_name": "travel_advice_index",
+              "title": "Foreign travel advice",
+              "withdrawn": false,
+              "links": {
+
+              },
+              "api_url": "https:\/\/www.gov.uk\/api\/content\/foreign-travel-advice",
+              "web_url": "https:\/\/www.gov.uk\/foreign-travel-advice"
+            }
+          ]
+        },
+        "api_url": "https:\/\/www.gov.uk\/api\/content\/foreign-travel-advice\/st-maarten",
+        "web_url": "https:\/\/www.gov.uk\/foreign-travel-advice\/st-maarten"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "\/api\/content\/foreign-travel-advice\/turks-and-caicos-islands",
+        "base_path": "\/foreign-travel-advice\/turks-and-caicos-islands",
+        "content_id": "f931c121-e8be-4b50-ab51-762e9741834e",
+        "description": "Latest travel advice for Turks and Caicos Islands including safety and security, entry requirements, travel warnings and health",
+        "document_type": "travel_advice",
+        "locale": "en",
+        "public_updated_at": "2016-03-31T12:30:40+00:00",
+        "schema_name": "travel_advice",
+        "title": "Turks and Caicos Islands (British Overseas Territory) travel advice",
+        "withdrawn": false,
+        "country": {
+          "slug": "turks-and-caicos-islands",
+          "name": "Turks and Caicos Islands",
+          "synonyms": [
+
+          ]
+        },
+        "change_description": "Latest update: Summary and Terrorism section: updated information and advice about the threat from terrorism following a review of the way in which the UK government describes the threat from terrorism in travel advice for all countries and territories; there's no change in the UK government\u2019s assessment of the level of threat from terrorism in the Turks and Caicos Islands",
+        "links": {
+          "parent": [
+            {
+              "analytics_identifier": null,
+              "api_path": "\/api\/content\/foreign-travel-advice",
+              "base_path": "\/foreign-travel-advice",
+              "content_id": "08d48cdd-6b50-43ff-a53b-beab47f4aab0",
+              "description": "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
+              "document_type": "travel_advice_index",
+              "locale": "en",
+              "public_updated_at": "2017-05-18T13:28:24Z",
+              "schema_name": "travel_advice_index",
+              "title": "Foreign travel advice",
+              "withdrawn": false,
+              "links": {
+
+              },
+              "api_url": "https:\/\/www.gov.uk\/api\/content\/foreign-travel-advice",
+              "web_url": "https:\/\/www.gov.uk\/foreign-travel-advice"
+            }
+          ]
+        },
+        "api_url": "https:\/\/www.gov.uk\/api\/content\/foreign-travel-advice\/turks-and-caicos-islands",
+        "web_url": "https:\/\/www.gov.uk\/foreign-travel-advice\/turks-and-caicos-islands"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "\/api\/content\/foreign-travel-advice\/taiwan",
+        "base_path": "\/foreign-travel-advice\/taiwan",
+        "content_id": "b486e8b6-fbe2-443d-acaa-cc0c5a8b4cfe",
+        "description": "Latest travel advice for Taiwan including safety and security, entry requirements, travel warnings and health",
+        "document_type": "travel_advice",
+        "locale": "en",
+        "public_updated_at": "2016-03-29T17:20:20+00:00",
+        "schema_name": "travel_advice",
+        "title": "Taiwan travel advice",
+        "withdrawn": false,
+        "country": {
+          "slug": "taiwan",
+          "name": "Taiwan",
+          "synonyms": [
+
+          ]
+        },
+        "change_description": "Latest update: Entry requirements section \u2013 if you\u2019re entering Taiwan using an Emergency Travel document (ETD) you must apply for a visit visa before travelling (unless you\u2019re travelling from mainland China, in which case you can get a visa on arrival)\r\n",
+        "links": {
+          "parent": [
+            {
+              "analytics_identifier": null,
+              "api_path": "\/api\/content\/foreign-travel-advice",
+              "base_path": "\/foreign-travel-advice",
+              "content_id": "08d48cdd-6b50-43ff-a53b-beab47f4aab0",
+              "description": "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
+              "document_type": "travel_advice_index",
+              "locale": "en",
+              "public_updated_at": "2017-05-18T13:28:24Z",
+              "schema_name": "travel_advice_index",
+              "title": "Foreign travel advice",
+              "withdrawn": false,
+              "links": {
+
+              },
+              "api_url": "https:\/\/www.gov.uk\/api\/content\/foreign-travel-advice",
+              "web_url": "https:\/\/www.gov.uk\/foreign-travel-advice"
+            }
+          ]
+        },
+        "api_url": "https:\/\/www.gov.uk\/api\/content\/foreign-travel-advice\/taiwan",
+        "web_url": "https:\/\/www.gov.uk\/foreign-travel-advice\/taiwan"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "\/api\/content\/foreign-travel-advice\/central-african-republic",
+        "base_path": "\/foreign-travel-advice\/central-african-republic",
+        "content_id": "f52ed25a-1c8f-497b-938e-066d008d5d73",
+        "description": "Latest travel advice for Central African Republic including safety and security, entry requirements, travel warnings and health",
+        "document_type": "travel_advice",
+        "locale": "en",
+        "public_updated_at": "2016-03-30T15:42:44+00:00",
+        "schema_name": "travel_advice",
+        "title": "Central African Republic travel advice",
+        "withdrawn": false,
+        "country": {
+          "slug": "central-african-republic",
+          "name": "Central African Republic",
+          "synonyms": [
+
+          ]
+        },
+        "change_description": "Latest update: this advice has been reviewed and re-issued without amendment ",
+        "links": {
+          "parent": [
+            {
+              "analytics_identifier": null,
+              "api_path": "\/api\/content\/foreign-travel-advice",
+              "base_path": "\/foreign-travel-advice",
+              "content_id": "08d48cdd-6b50-43ff-a53b-beab47f4aab0",
+              "description": "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
+              "document_type": "travel_advice_index",
+              "locale": "en",
+              "public_updated_at": "2017-05-18T13:28:24Z",
+              "schema_name": "travel_advice_index",
+              "title": "Foreign travel advice",
+              "withdrawn": false,
+              "links": {
+
+              },
+              "api_url": "https:\/\/www.gov.uk\/api\/content\/foreign-travel-advice",
+              "web_url": "https:\/\/www.gov.uk\/foreign-travel-advice"
+            }
+          ]
+        },
+        "api_url": "https:\/\/www.gov.uk\/api\/content\/foreign-travel-advice\/central-african-republic",
+        "web_url": "https:\/\/www.gov.uk\/foreign-travel-advice\/central-african-republic"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "\/api\/content\/foreign-travel-advice\/congo",
+        "base_path": "\/foreign-travel-advice\/congo",
+        "content_id": "438a3cd3-5936-462d-b7ed-fff0ea485af1",
+        "description": "Latest travel advice for Congo including safety and security, entry requirements, travel warnings and health\r\n\r\nThere is considered to be a heightened threat of terrorist attack globally against UK interests and British nationals, from groups or individuals motivated by the conflict in Iraq and Syria. You should be vigilant at this time.",
+        "document_type": "travel_advice",
+        "locale": "en",
+        "public_updated_at": "2016-03-28T12:13:26+00:00",
+        "schema_name": "travel_advice",
+        "title": "Congo travel advice",
+        "withdrawn": false,
+        "country": {
+          "slug": "congo",
+          "name": "Congo",
+          "synonyms": [
+
+          ]
+        },
+        "change_description": "Latest update: this advice has been reviewed and re-issued without amendment ",
+        "links": {
+          "parent": [
+            {
+              "analytics_identifier": null,
+              "api_path": "\/api\/content\/foreign-travel-advice",
+              "base_path": "\/foreign-travel-advice",
+              "content_id": "08d48cdd-6b50-43ff-a53b-beab47f4aab0",
+              "description": "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
+              "document_type": "travel_advice_index",
+              "locale": "en",
+              "public_updated_at": "2017-05-18T13:28:24Z",
+              "schema_name": "travel_advice_index",
+              "title": "Foreign travel advice",
+              "withdrawn": false,
+              "links": {
+
+              },
+              "api_url": "https:\/\/www.gov.uk\/api\/content\/foreign-travel-advice",
+              "web_url": "https:\/\/www.gov.uk\/foreign-travel-advice"
+            }
+          ]
+        },
+        "api_url": "https:\/\/www.gov.uk\/api\/content\/foreign-travel-advice\/congo",
+        "web_url": "https:\/\/www.gov.uk\/foreign-travel-advice\/congo"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "\/api\/content\/foreign-travel-advice\/somalia",
+        "base_path": "\/foreign-travel-advice\/somalia",
+        "content_id": "992befc4-32a3-4a1a-a034-c9cb2ff42bad",
+        "description": "Latest travel advice for Somalia including safety and security, entry requirements, travel warnings and health",
+        "document_type": "travel_advice",
+        "locale": "en",
+        "public_updated_at": "2016-03-21T14:47:52+00:00",
+        "schema_name": "travel_advice",
+        "title": "Somalia travel advice",
+        "withdrawn": false,
+        "country": {
+          "slug": "somalia",
+          "name": "Somalia",
+          "synonyms": [
+
+          ]
+        },
+        "change_description": "Latest update: Summary - the British Embassy in Mogadishu is unable to provide consular assistance; if you\u2019re in Somalia and need urgent help from the UK government (eg if you\u2019ve been arrested or you\u2019re concerned about forced marriage), contact the British High Commission in Nairobi",
+        "links": {
+          "parent": [
+            {
+              "analytics_identifier": null,
+              "api_path": "\/api\/content\/foreign-travel-advice",
+              "base_path": "\/foreign-travel-advice",
+              "content_id": "08d48cdd-6b50-43ff-a53b-beab47f4aab0",
+              "description": "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
+              "document_type": "travel_advice_index",
+              "locale": "en",
+              "public_updated_at": "2017-05-18T13:28:24Z",
+              "schema_name": "travel_advice_index",
+              "title": "Foreign travel advice",
+              "withdrawn": false,
+              "links": {
+
+              },
+              "api_url": "https:\/\/www.gov.uk\/api\/content\/foreign-travel-advice",
+              "web_url": "https:\/\/www.gov.uk\/foreign-travel-advice"
+            }
+          ]
+        },
+        "api_url": "https:\/\/www.gov.uk\/api\/content\/foreign-travel-advice\/somalia",
+        "web_url": "https:\/\/www.gov.uk\/foreign-travel-advice\/somalia"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "\/api\/content\/foreign-travel-advice\/eritrea",
+        "base_path": "\/foreign-travel-advice\/eritrea",
+        "content_id": "6b47e9b9-0942-48b5-8ee1-778699ac95f0",
+        "description": "Latest travel advice for Eritrea including safety and security, entry requirements, travel warnings and health",
+        "document_type": "travel_advice",
+        "locale": "en",
+        "public_updated_at": "2016-03-31T14:57:20+00:00",
+        "schema_name": "travel_advice",
+        "title": "Eritrea travel advice",
+        "withdrawn": false,
+        "country": {
+          "slug": "eritrea",
+          "name": "Eritrea",
+          "synonyms": [
+            "Sahel"
+          ]
+        },
+        "change_description": "Latest update: Entry requirements section \u2013 UK Emergency Travel Documents are accepted for entry, airside transit and exit from Eritrea",
+        "links": {
+          "parent": [
+            {
+              "analytics_identifier": null,
+              "api_path": "\/api\/content\/foreign-travel-advice",
+              "base_path": "\/foreign-travel-advice",
+              "content_id": "08d48cdd-6b50-43ff-a53b-beab47f4aab0",
+              "description": "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
+              "document_type": "travel_advice_index",
+              "locale": "en",
+              "public_updated_at": "2017-05-18T13:28:24Z",
+              "schema_name": "travel_advice_index",
+              "title": "Foreign travel advice",
+              "withdrawn": false,
+              "links": {
+
+              },
+              "api_url": "https:\/\/www.gov.uk\/api\/content\/foreign-travel-advice",
+              "web_url": "https:\/\/www.gov.uk\/foreign-travel-advice"
+            }
+          ]
+        },
+        "api_url": "https:\/\/www.gov.uk\/api\/content\/foreign-travel-advice\/eritrea",
+        "web_url": "https:\/\/www.gov.uk\/foreign-travel-advice\/eritrea"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "\/api\/content\/foreign-travel-advice\/french-polynesia",
+        "base_path": "\/foreign-travel-advice\/french-polynesia",
+        "content_id": "8dae3061-8bc3-4deb-8ac5-723957597716",
+        "description": "Latest travel advice for French Polynesia including safety and security, entry requirements, travel warnings and health",
+        "document_type": "travel_advice",
+        "locale": "en",
+        "public_updated_at": "2016-03-09T12:59:30+00:00",
+        "schema_name": "travel_advice",
+        "title": "French Polynesia travel advice",
+        "withdrawn": false,
+        "country": {
+          "slug": "french-polynesia",
+          "name": "French Polynesia",
+          "synonyms": [
+
+          ]
+        },
+        "change_description": "Latest update: this advice has been reviewed and re-issued without amendment\r\n",
+        "links": {
+          "parent": [
+            {
+              "analytics_identifier": null,
+              "api_path": "\/api\/content\/foreign-travel-advice",
+              "base_path": "\/foreign-travel-advice",
+              "content_id": "08d48cdd-6b50-43ff-a53b-beab47f4aab0",
+              "description": "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
+              "document_type": "travel_advice_index",
+              "locale": "en",
+              "public_updated_at": "2017-05-18T13:28:24Z",
+              "schema_name": "travel_advice_index",
+              "title": "Foreign travel advice",
+              "withdrawn": false,
+              "links": {
+
+              },
+              "api_url": "https:\/\/www.gov.uk\/api\/content\/foreign-travel-advice",
+              "web_url": "https:\/\/www.gov.uk\/foreign-travel-advice"
+            }
+          ]
+        },
+        "api_url": "https:\/\/www.gov.uk\/api\/content\/foreign-travel-advice\/french-polynesia",
+        "web_url": "https:\/\/www.gov.uk\/foreign-travel-advice\/french-polynesia"
+      }
+    ]
+  },
+  "description": "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
+  "details": {
+    "email_signup_link": "\/foreign-travel-advice\/email-signup",
+    "max_cache_time": 10
+  }
 }


### PR DESCRIPTION
This monitoring tool was still using the Content API to fetch data on
the Foreign Travel Advice page and Countries. We no longer support the
Content API, so we should be using the Content Store instead.

This commit changes the URL to be the Content Store URL and also fetches
the expected information in the correct place.

<img width="1434" alt="screen shot 2017-05-22 at 14 29 59" src="https://cloud.githubusercontent.com/assets/416701/26311157/3189be22-3efb-11e7-8b7b-f48879261ef5.png">

Trello: https://trello.com/c/Uo9tfmSE/139-investigate-who-is-using-travel-advice-endpoints-on-content-api-in-production