### PR TITLE
Fix the time used for tests to UTC

### DIFF
--- a/spec/features/travel_advice_alert_email_verification_spec.rb
+++ b/spec/features/travel_advice_alert_email_verification_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TravelAdviceAlertEmailVerifier do
 
   before do
     set_credentials
-    Timecop.freeze(Time.local(2016, 03, 31, 17, 30))
+    Timecop.freeze(Time.gm(2016, 03, 31, 17, 30))
   end
 
   after do


### PR DESCRIPTION
This stops intermittent failures depending on the local time of the
machine the tests are being run on.