### PR TITLE
Switch email alert tests to be based around title

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -37,8 +37,8 @@ task :run_travel_alerts do
       puts "All travel advice email alerts have been sent. Everything is okay!"
     else
       verifier.missing_alerts.each do |email, result|
-        /subject:(.*)/.match(result) do |country|
-          puts "#{email} has not received a travel advice email for #{country[1]}"
+        /subject:(.*)/.match(result) do |subject|
+          puts "#{email} has not receieved a travel advice alert email with a subject of #{[1]}"
         end
       end
 

--- a/lib/travel_advice_alerts.rb
+++ b/lib/travel_advice_alerts.rb
@@ -36,12 +36,12 @@ class TravelAdviceAlerts
       Time.now - 172800 <= updated_at && updated_at <= Time.now - 900
     end
 
-    def country
-      entry['country']['name']
+    def subject
+      entry['title']
     end
 
     def search_value
-      %Q("#{alert_time}" subject:#{country})
+      %("#{alert_time}" subject:"#{subject}")
     end
   end
 end

--- a/spec/features/example_travel_alert_feed.json
+++ b/spec/features/example_travel_alert_feed.json
@@ -387,24 +387,25 @@
       },
       {
         "analytics_identifier": null,
-        "api_path": "\/api\/content\/foreign-travel-advice\/eritrea",
-        "base_path": "\/foreign-travel-advice\/eritrea",
+        "api_path": "\/api\/content\/foreign-travel-advice\/sao-tome-and-principe",
+        "base_path": "\/foreign-travel-advice\/sao-tome-and-principe",
         "content_id": "6b47e9b9-0942-48b5-8ee1-778699ac95f0",
-        "description": "Latest travel advice for Eritrea including safety and security, entry requirements, travel warnings and health",
+        "description": "Latest travel advice for São Tomé and Principe including safety and security, entry requirements, travel warnings and health",
         "document_type": "travel_advice",
         "locale": "en",
         "public_updated_at": "2016-03-31T14:57:20+00:00",
         "schema_name": "travel_advice",
-        "title": "Eritrea travel advice",
+        "title": "São Tomé and Principe travel advice",
         "withdrawn": false,
         "country": {
-          "slug": "eritrea",
-          "name": "Eritrea",
+          "slug": "sao-tome-and-principe",
+          "name": "São Tomé and Principe",
           "synonyms": [
-            "Sahel"
+            "Sao Tome and Principe",
+            "Sao Tome & Principe"
           ]
         },
-        "change_description": "Latest update: Entry requirements section \u2013 UK Emergency Travel Documents are accepted for entry, airside transit and exit from Eritrea",
+        "change_description": "Money section –  travellers cheques are not accepted in Sao Tome and Principe",
         "links": {
           "parent": [
             {


### PR DESCRIPTION
The subject of an email is based upon a title field which the travel
advice publisher has access to edit. For the most part these are
consistent with the names of the countries however they need not be.

Where the subject originates:
https://github.com/alphagov/travel-advice-publisher/blob/master/app/presenters/email_alert_presenter.rb#L28-L30

This has led to some confusing problems where we thought diacritics were
being stripped out of emails as the ones for "São Tomé and Principe"
were given the subject of "Sao Tome & Principe travel advice".

This commit changes what is searched for in the mailbox to check that it
is the title attribute rather than the country name - which will allow
for subtle differences. Ideally we will deprecate the use of that title
field as it seems to be widely not used and when it is used causes
problems like this.

I've given this branch a spin and it passed where the existing one fails: https://deploy.publishing.service.gov.uk/job/travel-advice-email-alert-check/51405/