### PR TITLE
Fix travel advice output typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ feed](https://www.gov.uk/api/content/foreign-travel-advice).
 
 `bundle exec rake run` for the drug device alert checker
 
-`bundle exec rake run` for the travel advice alert checker
+`bundle exec rake run_travel_alerts` for the travel advice alert checker
 
 Both rake tasks will exit normally and not output anything if everything is
 okay.

--- a/Rakefile
+++ b/Rakefile
@@ -38,7 +38,7 @@ task :run_travel_alerts do
     else
       verifier.missing_alerts.each do |email, result|
         /subject:(.*)/.match(result) do |subject|
-          puts "#{email} has not receieved a travel advice alert email with a subject of #{[1]}"
+          puts "#{email} has not received a travel advice alert email with a subject of #{[1]}"
         end
       end
 

--- a/Rakefile
+++ b/Rakefile
@@ -38,7 +38,7 @@ task :run_travel_alerts do
     else
       verifier.missing_alerts.each do |email, result|
         /subject:(.*)/.match(result) do |subject|
-          puts "#{email} has not received a travel advice alert email with a subject of #{[1]}"
+          puts "#{email} has not received a travel advice alert email with a subject of #{subject[1]}"
         end
       end
 


### PR DESCRIPTION
Fix a few typos in the output and the README for travel advice monitoring.