### PR TITLE
Update travel advice monitoring following template changes

### DIFF
--- a/lib/travel_advice_alerts.rb
+++ b/lib/travel_advice_alerts.rb
@@ -3,7 +3,8 @@ require 'json'
 require 'time'
 
 class TravelAdviceAlerts
-  FEED_URL = "https://www.gov.uk/api/content/foreign-travel-advice"
+  FEED_URL = "https://www.gov.uk/api/content/foreign-travel-advice".freeze
+  EMAIL_DATE_FORMAT = "%l:%M%P, %-d %B %Y".freeze # make sure this matches email-alert-api
 
   def latest_travel_advice_alerts
     # Extract the countries updated from two days to one hour ago.
@@ -29,7 +30,7 @@ class TravelAdviceAlerts
     end
 
     def alert_time
-      updated_at.utc.strftime("%d-%m-%Y %H:%M %p GMT")
+      updated_at.utc.strftime(EMAIL_DATE_FORMAT)
     end
 
     def updated_recently?

--- a/spec/features/travel_advice_alert_email_verification_spec.rb
+++ b/spec/features/travel_advice_alert_email_verification_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe TravelAdviceAlertEmailVerifier do
         expect(verifier.missing_alerts.size).to eql(0)
         expect(
           a_request(:get, "https://www.googleapis.com/gmail/v1/users/me/messages").
-          with(query: { q: '"09-03-2016 12:59 PM GMT" subject:"Armenia travel advice" to:c@example.org' })
+          with(query: { q: '"12:59pm, 9 March 2016" subject:"Armenia travel advice" to:c@example.org' })
         ).not_to have_been_made
       end
 
@@ -52,7 +52,7 @@ RSpec.describe TravelAdviceAlertEmailVerifier do
           expect(verifier.have_all_alerts_been_emailed?).to eql(true)
           expect(
             a_request(:get, "https://www.googleapis.com/gmail/v1/users/me/messages").
-            with(query: { q: '"31-03-2016 14:57 PM GMT" subject:"Sao Tome & Principe travel advice" to:c@example.org' })
+            with(query: { q: '" 2:57pm, 31 March 2016" subject:"Sao Tome & Principe travel advice" to:c@example.org' })
           ).to have_been_made
         end
       end
@@ -65,7 +65,7 @@ RSpec.describe TravelAdviceAlertEmailVerifier do
 
           stub_request(
             :get, "https://www.googleapis.com/gmail/v1/users/me/messages").
-            with(query: { q: '"31-03-2016 15:24 PM GMT" subject:"Albania travel advice" to:c@example.org' }).
+            with(query: { q: '" 3:24pm, 31 March 2016" subject:"Albania travel advice" to:c@example.org' }).
             to_return(body: { resultSizeEstimate: 0 }.to_json, headers: { 'Content-Type' => 'application/json'})
         end
 
@@ -91,4 +91,3 @@ RSpec.describe TravelAdviceAlertEmailVerifier do
     end
   end
 end
-


### PR DESCRIPTION
We format dates different in the new emails so we need look for a different date string in the email.