### PR TITLE
Add a rake tasks to regenerate OAuth credentials

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,49 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task default: :spec
+def google_auth_client(additional_parameters = nil)
+  require "google/api_client/client_secrets"
+
+  unless File.exist?("client_secrets.json")
+    raise "`client_secrets.json` needs to be downloaded from the Google "\
+      "Developers Console and be present in the root directory of this repo."
+  end
+
+  client_secrets = Google::APIClient::ClientSecrets.load("client_secrets.json")
+  auth_client = client_secrets.to_authorization
+  auth_client.update!(
+    scope: "https://www.googleapis.com/auth/gmail.readonly",
+    redirect_uri: "http://localhost/oauth",
+    additional_parameters: additional_parameters
+  )
+  auth_client
+end
+
+task default: %i[spec lint]
+
+task :lint do
+  sh "bundle exec govuk-lint-ruby --format clang lib spec Gemfile"
+end
+
+# OAuth step 1: get the URL to visit for authorisation
+task :get_oauth_url do
+  auth_client = google_auth_client(
+    {
+      "access_type" => "offline"
+    }
+  )
+  puts auth_client.authorization_uri
+end
+
+# OAuth step 2: extract the code from the callback URL and use
+# to get the OAuth token
+task :get_oauth_token, [:auth_code] do |_t, args|
+  auth_client = google_auth_client
+  auth_client.code = args[:auth_code]
+  auth_client.fetch_access_token!
+  auth_client.client_secret = nil
+  puts auth_client.to_json
+end
 
 task :run do
   require_relative "./lib/drug_alert_email_verifier"

--- a/docs/regenerating-google-oauth-credentials.md
+++ b/docs/regenerating-google-oauth-credentials.md
@@ -1,0 +1,21 @@
+# Regenerating Google OAuth credentials
+
+The `GOOGLE_OAUTH_CREDENTIALS` environment variable contains a JSON
+representation of the OAuth credentials used to connect to the email
+account to check for email alerts.
+
+If these credentials stop working (for example, they are revoked), they
+can be regenerated using the following steps:
+
+1. Log in to the Google account that will be checked for email alerts.
+   For best results, do this in a private browsing window.
+2. Run `bundle exec rake get_oauth_url` to get a Google authorisation
+   URL.
+3. Visit this URL in the browser window from step 1.
+4. Allow permission for this app to log into the relevant email account.
+5. The browser will redirect to a non-existent localhost URL - copy the
+   contents of the `code` query string parameter from this URL.
+6. Run `bundle exec rake get_oauth_token[<code>]`, where `<code>` is
+   the code you extracted in step 5.
+7. Copy the output of the command and replace the existing credentials
+   in [production hieradata](https://github.com/alphagov/govuk-secrets/blob/master/puppet/hieradata/production_credentials.yaml).


### PR DESCRIPTION
This commit adds two new rake tasks that together allow for the easy regeneration of the Google OAuth credentials used to log in to the email account that is checked for email alerts. There is also documentation for how to run this process.

As a bonus, linting is now available via a rake task and is run by default after the tests.