### PR TITLE
Raise exception after retries exhausted

### DIFF
--- a/lib/task_runner.rb
+++ b/lib/task_runner.rb
@@ -7,9 +7,8 @@ class TaskRunner
       verifier.run_report
     rescue StandardError => e
       GovukError.notify(e)
-      unless (tries -= 1).zero?
-        retry
-      end
+      retry unless (tries -= 1).zero?
+      raise
     else
       yield
     end

--- a/spec/lib/task_runner_spec.rb
+++ b/spec/lib/task_runner_spec.rb
@@ -11,13 +11,17 @@ RSpec.describe TaskRunner do
       it "tells GovukError and retries the specified number of times" do
         expect(verifier).to receive(:run_report).exactly(3).times
         expect(GovukError).to receive(:notify).with(StandardError).exactly(3).times
-        verified = false
+        @verified = false
 
-        TaskRunner.new.verify_with_retries(retries: 3, verifier: verifier) do
-          verified = true
+        def run_verify_with_retries
+          TaskRunner.new.verify_with_retries(retries: 3, verifier: verifier) do
+            @verified = true
+          end
         end
 
-        expect(verified).to be false
+        expect { run_verify_with_retries }.to raise_error(StandardError)
+
+        expect(@verified).to be false
       end
     end
 


### PR DESCRIPTION
Although we currently send the exception to Sentry, by not raising the exception directly, the Rake tasks finishes with status code 0 implies that the run was successful.

[Trello Card](https://trello.com/c/cntASr0s/170-email-alert-monitoring-reports-success-if-it-cant-connect-to-gmail-2)