### PR TITLE
Add another FSN notice to acknowledged emails

### DIFF
--- a/lib/email_verifier.rb
+++ b/lib/email_verifier.rb
@@ -10,6 +10,7 @@ class EmailVerifier
     %{subject:"SureSigns VS & VM patient monitors and Viewing stations manufactured before May 2018: risk of batteries overheating or igniting (MDA/2018/031)"},
     %{subject:"Flex connectors in Halyard Closed Suction Kits – risk of interruption of ventilation (MDA/2018/030)"},
     %{subject:"Field safety notices - 26 to 30 November 2018"},
+    %{subject:"Field Safety Notice - 19 November to 23 November 2018"},
   ].freeze
 
   def initialize


### PR DESCRIPTION
The email was sent out but the title subsequently amended (long dash replaced with a short dash).