### PR TITLE
Add Field Safety Notice to ignore list

### DIFF
--- a/lib/email_verifier.rb
+++ b/lib/email_verifier.rb
@@ -12,7 +12,8 @@ class EmailVerifier
     %{subject:"Field safety notices - 26 to 30 November 2018"},
     %{subject:"Field Safety Notice - 19 November to 23 November 2018"},
     %{subject:"Implantable cardiac pacemakers: specific brands of dual chamber pacemakers - risk of syncope due to pause in pacing therapy (MDA/2019/008)"},
-    %{subject:"Drug Alert Class 4: Paracetamol Infusion, Accord. (MDR 07-02/19)"}
+    %{subject:"Drug Alert Class 4: Paracetamol Infusion, Accord. (MDR 07-02/19)"},
+    %{subject:"Field Safety Notice: 8 to 12 April 2019"}
   ].freeze
 
   def initialize


### PR DESCRIPTION
This was published as `Field Safety Notice: 08-12 April 2019` and the email alert sent out with that subject.  The title has changed subsequently, so the email alert verifier is looking for the new title.