### PR TITLE
Add Field Safety Notice to ignore list

### DIFF
--- a/lib/email_verifier.rb
+++ b/lib/email_verifier.rb
@@ -13,7 +13,8 @@ class EmailVerifier
     %{subject:"Field Safety Notice - 19 November to 23 November 2018"},
     %{subject:"Implantable cardiac pacemakers: specific brands of dual chamber pacemakers - risk of syncope due to pause in pacing therapy (MDA/2019/008)"},
     %{subject:"Drug Alert Class 4: Paracetamol Infusion, Accord. (MDR 07-02/19)"},
-    %{subject:"Field Safety Notice: 8 to 12 April 2019"}
+    %{subject:"Field Safety Notice: 8 to 12 April 2019"},
+    %{subject:"Field Safety Notice: 15 to 19 April 2019"}
   ].freeze
 
   def initialize


### PR DESCRIPTION
This was published as `Field Safety Notice: 15-19 April 2019` and the email alert sent out with that subject.  The title has changed subsequently, so the email alert verifier is looking for the new title.