### PR TITLE
Add drug alert to ignore list

### DIFF
--- a/lib/email_verifier.rb
+++ b/lib/email_verifier.rb
@@ -14,7 +14,8 @@ class EmailVerifier
     %{subject:"Implantable cardiac pacemakers: specific brands of dual chamber pacemakers - risk of syncope due to pause in pacing therapy (MDA/2019/008)"},
     %{subject:"Drug Alert Class 4: Paracetamol Infusion, Accord. (MDR 07-02/19)"},
     %{subject:"Field Safety Notice: 8 to 12 April 2019"},
-    %{subject:"Field Safety Notice: 15 to 19 April 2019"}
+    %{subject:"Field Safety Notice: 15 to 19 April 2019"},
+    %{subject:"Aisys and Aisys CS2 anaesthesia devices with Et Control option and software versions 11, 11SP01 and 11SP02 – risk of patient awareness due to inadequate anaesthesia"}
   ].freeze
 
   def initialize


### PR DESCRIPTION
"Aisys and Aisys CS2 anaesthesia devices with Et Control option and software versions 11, 11SP01 and 11SP02 – risk of patient awareness due to inadequate anaesthesia" had a title update.

Confirmed that the original email alert was sent out.