### PR TITLE
Add content to be ignored by email-alert-check

### DIFF
--- a/lib/email_verifier.rb
+++ b/lib/email_verifier.rb
@@ -17,7 +17,8 @@ class EmailVerifier
     %{subject:"Field Safety Notice: 15 to 19 April 2019"},
     %{subject:"Aisys and Aisys CS2 anaesthesia devices with Et Control option and software versions 11, 11SP01 and 11SP02 – risk of patient awareness due to inadequate anaesthesia (MDA/2019/022)"},
     %{subject:"Professional use defibrillator/monitor: Efficia DFM100 (Model number 866199)  – risk of failure to switch on or unexpected restart (MDA/2019/039)"},
-    %{subject:"Class 2 Medicines recall: Emerade 150, 300 and 500 microgram solution for injection in pre-filled syringe (EL(19)A/39)"}
+    %{subject:"Class 2 Medicines recall: Emerade 150, 300 and 500 microgram solution for injection in pre-filled syringe (EL(19)A/39)"},
+    %{subject:"Professional use defibrillator/monitor: all HeartStart XL+ (Model number 861290) - risk of failure to deliver therapy (MDA/2020/003)"}
   ].freeze
 
   def initialize


### PR DESCRIPTION
The document added has had it's title changed since publishing (emails
sent out) so this adds the updated title to the ignore list for the
alert.

Failed deploy:
https://deploy.blue.production.govuk.digital/job/email-alert-check/1062/console