### PR TITLE
Add email title to be acknowledged by email-alert-check

### DIFF
--- a/lib/email_verifier.rb
+++ b/lib/email_verifier.rb
@@ -18,7 +18,8 @@ class EmailVerifier
     %{subject:"Aisys and Aisys CS2 anaesthesia devices with Et Control option and software versions 11, 11SP01 and 11SP02 – risk of patient awareness due to inadequate anaesthesia (MDA/2019/022)"},
     %{subject:"Professional use defibrillator/monitor: Efficia DFM100 (Model number 866199)  – risk of failure to switch on or unexpected restart (MDA/2019/039)"},
     %{subject:"Class 2 Medicines recall: Emerade 150, 300 and 500 microgram solution for injection in pre-filled syringe (EL(19)A/39)"},
-    %{subject:"Professional use defibrillator/monitor: all HeartStart XL+ (Model number 861290) - risk of failure to deliver therapy (MDA/2020/003)"}
+    %{subject:"Professional use defibrillator/monitor: all HeartStart XL+ (Model number 861290) - risk of failure to deliver therapy (MDA/2020/003)"},
+    %{subject:"Company led drug alert – Iohexol 350mg/ml and 300 mg I/ml solution for injection (CLDA (20)A/01)"}
   ].freeze
 
   def initialize


### PR DESCRIPTION
The title for this content was changed after e-mails were sent, causing the email-alert-check to fail

https://deploy.blue.production.govuk.digital/job/email-alert-check/1496/console

This adds the email title to the acknowledged list, following guidance here
https://docs.publishing.service.gov.uk/manual/alerts/email-alerts.html#troubleshooting-failed-checks