### PR TITLE
Jenkinsfile: Don't specify dirs to lint

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ node {
     }
 
     stage("Lint Ruby") {
-      govuk.lintRuby("app lib spec test")
+      govuk.lintRuby()
     }
 
     stage("Run tests") {


### PR DESCRIPTION
- This was removed from our core Jenkins library in https://github.com/alphagov/govuk-jenkinslib/pull/66 as we now lint everything by default.