### PR TITLE
Limit max results to 10,000

### DIFF
--- a/lib/inbox.rb
+++ b/lib/inbox.rb
@@ -8,7 +8,7 @@ class Inbox
 private
 
   def messages_for_query(query)
-    service.list_user_messages("me", q: query)
+    service.list_user_messages("me", q: query, max_results: 10000)
   end
 
   def service

--- a/spec/features/medical_safety_alert_email_verification_spec.rb
+++ b/spec/features/medical_safety_alert_email_verification_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Drug email alert verifier" do
   def stub_message_request(to_email:, from_email:, subject:, result:)
     query = "subject:%22#{subject.gsub(' ', '%20')}%22%20from:#{from_email.gsub('+', '%2B')}%20to:#{to_email.gsub('+', '%2B')}"
 
-    stub_request(:get, "https://www.googleapis.com/gmail/v1/users/me/messages?q=#{query}").
+    stub_request(:get, "https://www.googleapis.com/gmail/v1/users/me/messages?maxResults=10000&q=#{query}").
       to_return(body: { resultSizeEstimate: result }.to_json, headers: { "Content-Type" => "application/json" })
   end
 

--- a/spec/features/travel_advice_alert_email_verification_spec.rb
+++ b/spec/features/travel_advice_alert_email_verification_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe EmailVerifier::TravelAdvice do
           expect(verifier.have_all_alerts_been_emailed?).to eql(true)
           expect(
             a_request(:get, "https://www.googleapis.com/gmail/v1/users/me/messages").
-            with(query: { q: '" 3:57pm, 31 March 2016" subject:"Sao Tome & Principe travel advice" from:c@example.org to:a@example.org' }),
+            with(query: { q: '" 3:57pm, 31 March 2016" subject:"Sao Tome & Principe travel advice" from:c@example.org to:a@example.org', maxResults: "10000" }),
           ).to have_been_made
         end
       end
@@ -55,7 +55,7 @@ RSpec.describe EmailVerifier::TravelAdvice do
           stub_request(:get, EmailSearch::TravelAdvice::HEALTHCHECK_URL).to_return(body: json)
 
           stub_request(:get, "https://www.googleapis.com/gmail/v1/users/me/messages")
-            .with(query: { q: '" 4:24pm, 31 March 2016" subject:"Albania travel advice" from:c@example.org to:a@example.org' })
+            .with(query: { q: '" 4:24pm, 31 March 2016" subject:"Albania travel advice" from:c@example.org to:a@example.org', maxResults: "10000" })
             .to_return(body: { resultSizeEstimate: 0 }.to_json, headers: { "Content-Type" => "application/json" })
         end
 


### PR DESCRIPTION
Our inbox currently contains 180,000 emails, and this means that querying it takes ages and sometimes time out. By limiting it to 10,000 results, the query is much faster.

I wasn't sure what number to pick, so we might need to tune it, but this feels reasonable for now.