### PR TITLE
Acknowledge South Sudan travel advice

### DIFF
--- a/lib/email_verifier.rb
+++ b/lib/email_verifier.rb
@@ -23,6 +23,7 @@ class EmailVerifier
     %{subject:"Class 4 Medicines Defect Information: Memantine 10mg Film-Coated Tablets, PL 20416/0260, (EL (20)A/11)"},
     %{subject:"All T34 and T34L (T60) ambulatory syringe pumps – check pumps before each use due to risk of under-infusion and no alarm (MDA/2020/007)"},
     %{subject:"Various Olympus duodenoscope models: do not use if elevator wires are frayed or damaged as these may cause lacerations to patients and users (MDA/2020/008) "},
+    %{" 5:00pm, 15 May 2020" subject:"South Sudan travel advice"},
   ].freeze
 
   def initialize


### PR DESCRIPTION
For some reason, South Sudan travel advice subjects in the content
change in email alert api are being populated as `South Sudan`. This
fails the email alert check because we are searching for `South Sudan
travel advice` in our checks.

Add South Sudan travel advice to the acknowledge list so we can get some
breathing room to figure out why the content change is being populated
incorrectly.