### PR TITLE
Remove South Sudan override

### DIFF
--- a/lib/email_verifier.rb
+++ b/lib/email_verifier.rb
@@ -23,7 +23,6 @@ class EmailVerifier
     %{subject:"Class 4 Medicines Defect Information: Memantine 10mg Film-Coated Tablets, PL 20416/0260, (EL (20)A/11)"},
     %{subject:"All T34 and T34L (T60) ambulatory syringe pumps – check pumps before each use due to risk of under-infusion and no alarm (MDA/2020/007)"},
     %{subject:"Various Olympus duodenoscope models: do not use if elevator wires are frayed or damaged as these may cause lacerations to patients and users (MDA/2020/008) "},
-    %{" 5:00pm, 15 May 2020" subject:"South Sudan travel advice"},
   ].freeze
 
   def initialize


### PR DESCRIPTION
A major update for South Sudan travel advice was published with a
title of `South Sudan`. This was received by Email Alert Api and
subsequenty processed. A minor update was published from Travel Advice
Publisher and the title was changed to `South Sudan travel advice`.

When the monitoring job was called, it searched the courtesy copies
email group for an email with a subject that included the words
`South Sudan travel advice`. The search for this email failed because
the actual email sent had a title that only included `South Sudan`.

The exception was put in place to stop the alert and resolve the
incident. It is no longer needed because we only test for emails that
have been sent out up to 2 days ago.