### PR TITLE
Add Medical Devices Safety Bulletin to acknowledge list

### DIFF
--- a/lib/email_verifier.rb
+++ b/lib/email_verifier.rb
@@ -27,6 +27,7 @@ class EmailVerifier
     %{subject:"Class 4 Medicines Defect Information: Memantine 10mg Film-Coated Tablets, PL 20416/0260, (EL (20)A/11)"},
     %{subject:"All T34 and T34L (T60) ambulatory syringe pumps – check pumps before each use due to risk of under-infusion and no alarm (MDA/2020/007)"},
     %{subject:"Various Olympus duodenoscope models: do not use if elevator wires are frayed or damaged as these may cause lacerations to patients and users (MDA/2020/008) "},
+    %{subject:"Medical Devices Safety Bulletin (MDSB/2020/01)"},
     %(" 2:21pm, 8 June 2020" subject:"South Sudan travel advice"),
     %(" 2:20pm, 8 June 2020" subject:"Venezuela travel advice"),
     %(" 2:19pm, 8 June 2020" subject:"Uruguay travel advice"),


### PR DESCRIPTION
Add the medical devices safety bulletin to the ack list. We're confident that the service is working properly but this email didn't send. This is cauing an alert so should be added to the list.