### PR TITLE
Ignore field safety notice 3-7 May alert

### DIFF
--- a/lib/email_verifier.rb
+++ b/lib/email_verifier.rb
@@ -31,6 +31,7 @@ class EmailVerifier
     %(" 2:21pm, 8 June 2020" subject:"South Sudan travel advice"),
     %(" 2:20pm, 8 June 2020" subject:"Venezuela travel advice"),
     %(" 2:19pm, 8 June 2020" subject:"Uruguay travel advice"),
+    %(subject:"Field Safety Notices: 3 to 7 May 2021"),
   ].freeze
 
   def initialize


### PR DESCRIPTION
This PR ignores the field safety notice for 3-7 May 2021; the courtesy copy has been verified to have been received. The only other way to fix the alert would be to reslug the field safety notice, then republish that as a major change to trigger a new courtesy copy email.