### PR TITLE
Use supported setup-ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
       - uses: actions/cache@v1
         with:
           path: vendor/bundle


### PR DESCRIPTION
This PR switches the CI build to use `ruby/setup-ruby`, which is supported and which will automatically read the contents of `.ruby-version` to figure out which Ruby version to install.