### PR TITLE
Containerise email-alert-monitoring

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.dockerignore
+.git
+.github
+.gitignore
+Dockerfile
+README.md
+spec
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+ARG ruby_version=3.1.2
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
+
+
+FROM $builder_image AS builder
+
+WORKDIR $APP_HOME
+COPY Gemfile* .ruby-version ./
+RUN bundle install
+COPY . .
+
+
+FROM $base_image
+
+ENV GOVUK_APP_NAME=email-alert-monitoring
+
+WORKDIR $APP_HOME
+COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $APP_HOME .
+
+USER app
+CMD ["puma"]


### PR DESCRIPTION
This will allow us to run the current job which run in jenkins in AWS EKS.
https://deploy.blue.production.govuk.digital/job/travel-advice-email-alert-check/configure


I have tested this by local docker build and running: the rake tests needed:
rake run_medical_alerts
rake run_travel_alerst



More detauls can be found on the below trello card: https://trello.com/c/qBfopr21/1184-medicalsafetyemailalertcheck-traveladviceemailalertcheck-jenkins-job-move-to-eks