### PR TITLE
Add prometheus push on valid run

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "tzinfo"
 
 gem "govuk_app_config"
 gem "plek"
+gem "prometheus-client"
 gem "pry-byebug"
 gem "rspec"
 gem "rss"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,7 @@ GEM
     parser (3.2.1.1)
       ast (~> 2.4.1)
     plek (5.0.0)
+    prometheus-client (4.2.0)
     prometheus_exporter (2.0.8)
       webrick
     pry (0.14.2)
@@ -233,6 +234,7 @@ DEPENDENCIES
   google-api-client
   govuk_app_config
   plek
+  prometheus-client
   pry-byebug
   rake
   rspec

--- a/lib/prometheus_reporter.rb
+++ b/lib/prometheus_reporter.rb
@@ -1,0 +1,23 @@
+require "prometheus/client"
+require "prometheus/client/push"
+
+class PrometheusReporter
+  def initialize(name)
+    @name = name
+    @registry = Prometheus::Client.registry
+  end
+
+  def record_successful_run
+    successful_run = Prometheus::Client::Gauge.new(symbol, docstring: "Time of last run where no missing emails were detected")
+    successful_run.set_to_current_time
+    @registry.register(successful_run)
+  end
+
+  def symbol
+    "#{@name}_last_successful_run_timestamp_seconds".to_sym
+  end
+
+  def push
+    Prometheus::Client::Push.new(job: "email-alert-monitoring", gateway: ENV.fetch("PROMETHEUS_PUSHGATEWAY_URL")).add(@registry)
+  end
+end


### PR DESCRIPTION
Add ability to push successful run information to Prometheus PushGateway, so that a freshness alert can be added (which will then set off alarms/pagerduty calls, etc).

https://trello.com/c/d0yJFWgK/2146-update-email-alert-monitoring-so-that-it-can-be-tested-on-integration-and-push-alerts-to-prometheus