### PR TITLE
Silence false alarm for medical safety alert

### DIFF
--- a/lib/email_verifier.rb
+++ b/lib/email_verifier.rb
@@ -32,6 +32,7 @@ class EmailVerifier
     %(" 2:20pm, 8 June 2020" subject:"Venezuela travel advice"),
     %(" 2:19pm, 8 June 2020" subject:"Uruguay travel advice"),
     %(subject:"Field Safety Notices: 3 to 7 May 2021"),
+    %(subject:"Company led medicines recall: Quantum Pharmaceutical, Diltiazem HCl 2% Cream [unlicensed medicine], CLMR (23)A/05"),
   ].freeze
 
   def initialize


### PR DESCRIPTION
The page has been renamed since it was published (to fix a typo), meaning its title no longer matches the title in the email alert.