### PR TITLE
Acknowledge Fiji travel advice email

### DIFF
--- a/lib/email_verifier.rb
+++ b/lib/email_verifier.rb
@@ -31,6 +31,7 @@ class EmailVerifier
     %(" 2:21pm, 8 June 2020" subject:"South Sudan travel advice"),
     %(" 2:20pm, 8 June 2020" subject:"Venezuela travel advice"),
     %(" 2:19pm, 8 June 2020" subject:"Uruguay travel advice"),
+    %(" 4:18pm, 27 September 2023" subject:"Fiji travel advice"),
     %(subject:"Field Safety Notices: 3 to 7 May 2021"),
     %(subject:"Company led medicines recall: Quantum Pharmaceutical, Diltiazem HCl 2% Cream [unlicensed medicine], CLMR (23)A/05"),
   ].freeze


### PR DESCRIPTION
We received a critical alert regarding a Fiji travel advice email. The email arrived one minute later than the time it was published. Therefore the timestamps did not match up. 

We used the format from this PR: https://github.com/alphagov/email-alert-monitoring/pull/63/files. 
To view the expected time in the Jenkins job, we added a `puts date.inspect` to `def entry_to_query(entry)` in `lib/email_search/travel_advice.rb`.

Paired with @ChrisBAshton